### PR TITLE
nbody shaders now fixed: avoiding NaN, rescaling before draw

### DIFF
--- a/shaders/nbody_acc.comp.glsl
+++ b/shaders/nbody_acc.comp.glsl
@@ -28,13 +28,16 @@ void main() {
     //     gl_WorkGroupID * gl_WorkGroupSize + gl_LocalInvocationID.
     uint idx = gl_GlobalInvocationID.x;
 
+    // star contribution
     vec3 p = Pos[idx];
     float dist = length(p);
-    vec3 acc = G * starMass * p / (dist * dist * dist);
+    vec3 acc = -(G * starMass * p) / (dist * dist * dist + 0.0001); // gotta jitter to avoid NaN
+
+    // planet-planet contributions
     for (int i = 0; i < numPlanets; i++) {
-        vec3 v = Pos[i] - p;
+        vec3 v = p - Pos[i];
         float d = length(v);
-        acc += G * planetMass * v / (d * d * d);
+        acc -= (G * planetMass * v) / (d * d * d + 0.0001); // gotta jitter to avoid NaN
     }
     Acc[idx] = acc;
 }

--- a/shaders/planet.geom.glsl
+++ b/shaders/planet.geom.glsl
@@ -6,8 +6,10 @@ layout(points) in;
 layout(points) out;
 layout(max_vertices = 1) out;
 
+
+
 void main() {
-    vec3 Position = gl_in[0].gl_Position.xyz;
+    vec3 Position = gl_in[0].gl_Position.xyz / 1e2;
     gl_Position = u_projMatrix * vec4(Position, 1.0);
     EmitVertex();
     EndPrimitive();

--- a/src/nbody.cpp
+++ b/src/nbody.cpp
@@ -36,6 +36,8 @@ static GLuint initComputeProg(const char *path) {
     const char *cs_str;
     cs_str = glslUtility::loadFile(path, cs_len);
 
+	printf(cs_str);
+
     glShaderSource(cs, 1, &cs_str, &cs_len);
 
     GLint status;


### PR DESCRIPTION
It seems to work now! What I did:
-changed gravity calculation for planet-star influence. I think the force was backwards before. I also poked the planet-planet calculation just to be consistent
-added a jitter to these calculations to avoid a NaN case that seemed to exist before (vanishing planets)
-added scaling to the geometry shader so more of the planets are drawn in view

This took... a little too long
